### PR TITLE
Swap order of clearing repl and evaluating code.

### DIFF
--- a/js/modules/evaluator.js
+++ b/js/modules/evaluator.js
@@ -75,8 +75,8 @@ class Evaluator {
     // the after callback until all the setup in this function is complete.
     // Which is exactly what queueMicrotask is for, it seems. So here we are.
     f.onload = () => {
-      if (after) queueMicrotask(after);
       queueMicrotask(() => this.repl.restart());
+      if (after) queueMicrotask(after);
     };
 
     Object.entries(this.config).forEach(([k, v]) => {


### PR DESCRIPTION
When I added the code to clear the repl on code reload, I didn't think hard enough about the ordering so it was evaluating code and then resetting the REPL which meant any console.logging that happened when the code was loaded got immediately wiped out. This change fixes that.