### PR TITLE
Remove the reset questions button on quizes.

### DIFF
--- a/js/expressions-game.js
+++ b/js/expressions-game.js
@@ -404,8 +404,11 @@ const setup = async () => {
       expressions.checkAnswer(e.target.value);
     }
   };
-
-  $('#reset').onclick = () => expressions.resetAnswers();
+  if ($('#shuffleExpressions')) {
+    $('#reset').remove();
+  } else {
+    $('#reset').onclick = () => expressions.resetAnswers();
+  }
 
   document.querySelectorAll('.questions code').forEach(
     (e) =>


### PR DESCRIPTION
Perhaps should rename the `#shuffleExpressions` element to `#isQuiz` or something or better yet find a way to wire this info through a data attribute. This is kinda a kludge.